### PR TITLE
Add Assign Issue workflow

### DIFF
--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -1,0 +1,24 @@
+name: Assign Issue
+
+on:
+  schedule:
+    - cron: 0 0 * * *
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+
+jobs:
+  assign:
+    permissions:
+      issues: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign the user or unassign stale assignments
+        uses: takanome-dev/assign-issue-action@2.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          maintainers: 'noisyfox,softfever'
+          days_until_unassign: 30
+          block_unassign: false
+          reminder_days: 7
+          max_assignments: 12


### PR DESCRIPTION
Allow users to assign issues to themselves.

I don't know if its comments (i.e. unassigning) affects orca bot's inactivity and stale. Probably. I didn't see a way for actions/stale to exempt particular comments. This is set for 30 days and stale for 90 days, so if people are using this the stale timing can jump up to 120 days.
